### PR TITLE
Add a Makefile with install and test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 install:
 	sudo apt-get update
 	sudo apt-get -y install expect
+	git clone https://github.com/docopt/docopts.git
+	cd docopts && ./get_docopts.sh
+	sudo cp docopts/docopts /usr/local/bin
+	rm -rf docopts
+	export PATH=$PATH:./bin:./src/lib
 
+test:
+	ccli --help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+install:
+	sudo apt-get update
+	sudo apt-get -y install expect
+


### PR DESCRIPTION
The install target installs expect and docopts but not Culberson's colouring programs. The test target merely runs the help command because nothing else will work without Culberson's programs.